### PR TITLE
Add translation utilities and API key guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,35 @@ Common tasks:
   - Prepare: `python scripts/manual_docx_translation.py prepare --input inputs/source.docx --template translations/source_template.json`
   - Apply:   `python scripts/manual_docx_translation.py apply --input inputs/source.docx --translations translations/source_translations.json --output outputs/source_en.docx`
 
+### Security: API Key Management
+
+**Best practices for handling API keys:**
+
+1. **Never commit keys to the repository**
+   - Add `.env` to `.gitignore`
+   - Use environment variables or secret managers
+
+2. **Use dotenv or direnv**
+   ```bash
+   # Install python-dotenv
+   pip install python-dotenv
+
+   # Create .env file (gitignored)
+   echo "OPENAI_API_KEY=sk-..." > .env
+   ```
+
+3. **Scope keys per run**
+   ```bash
+   # Temporary key for single command
+   OPENAI_API_KEY=sk-... python scripts/translate_pptx_inplace.py ...
+   ```
+
+4. **Avoid shell history leaks**
+   ```bash
+   # Prefix with space to avoid history (if HISTCONTROL=ignorespace)
+    export OPENAI_API_KEY=sk-...
+   ```
+
 —
 
 # 🚀 PowerPoint Translation Pipeline (JA→EN)

--- a/scripts/manual_docx_translation.py
+++ b/scripts/manual_docx_translation.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import argparse
 import io
 import json
+import unicodedata
 import zipfile
 from pathlib import Path
 from typing import Dict, Iterable, List, Tuple
@@ -30,6 +31,12 @@ from docx import Document
 
 
 W_NS = "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}"
+
+
+def _norm(text: str) -> str:
+    """Normalize text for stable matching."""
+
+    return unicodedata.normalize("NFKC", text)
 
 
 def collect_segments(docx_path: Path) -> List[str]:
@@ -43,9 +50,10 @@ def collect_segments(docx_path: Path) -> List[str]:
             return
         if not text.strip():
             return
-        if text not in seen:
+        key = _norm(text)
+        if key not in seen:
             segments.append(text)
-            seen.add(text)
+            seen.add(key)
 
     for paragraph in document.paragraphs:
         add_text(paragraph.text)
@@ -87,12 +95,10 @@ def translate_docx(
                 root = ET.fromstring(data)
                 for paragraph in root.iter(f"{W_NS}p"):
                     src_text = paragraph_text(paragraph)
-                    lookup = src_text.strip()
+                    lookup = _norm(src_text.strip())
                     if not lookup:
                         continue
-                    if src_text in translation_map:
-                        replace_paragraph_text(paragraph, translation_map[src_text])
-                    elif lookup in translation_map:
+                    if lookup in translation_map:
                         replace_paragraph_text(paragraph, translation_map[lookup])
                     else:
                         missing.append(src_text)
@@ -114,7 +120,7 @@ def load_translation_map(translations_path: Path) -> Dict[str, str]:
             continue
         if not en.strip():
             raise ValueError(f"Missing English translation for segment: {jp}")
-        mapping[jp] = en
+        mapping[_norm(jp)] = en
     return mapping
 
 

--- a/scripts/translate_pptx_inplace.py
+++ b/scripts/translate_pptx_inplace.py
@@ -1442,9 +1442,7 @@ def main():
             if "gemini" in args.model.lower():
                 logging.error("Gemini models are not supported with --concurrency > 1. Use concurrency=1 or an OpenAI model.")
                 sys.exit(2)
-            api_key = os.getenv("OPENAI_API_KEY")
-            base_url = os.getenv("OPENAI_BASE_URL", "").strip() or None
-            async_client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+            async_client = AsyncOpenAI(api_key=api_key, base_url=base_url or None)
             
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)

--- a/scripts/translate_pptx_inplace.py
+++ b/scripts/translate_pptx_inplace.py
@@ -1439,10 +1439,12 @@ def main():
         if args.concurrency > 1:
             # Async path
             print(f"Async translation: {len(missing)} items, concurrency={args.concurrency}")
-            if base_url:
-                async_client = AsyncOpenAI(api_key=api_key, base_url=base_url)
-            else:
-                async_client = AsyncOpenAI(api_key=api_key)
+            if "gemini" in args.model.lower():
+                logging.error("Gemini models are not supported with --concurrency > 1. Use concurrency=1 or an OpenAI model.")
+                sys.exit(2)
+            api_key = os.getenv("OPENAI_API_KEY")
+            base_url = os.getenv("OPENAI_BASE_URL", "").strip() or None
+            async_client = AsyncOpenAI(api_key=api_key, base_url=base_url)
             
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)

--- a/scripts/validate_translation_catalogs.py
+++ b/scripts/validate_translation_catalogs.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Validate and normalize translation catalog JSON files."""
+import json
+import unicodedata
+import sys
+from pathlib import Path
+
+
+def validate_catalog(path: Path) -> list[str]:
+    """Validate a translation catalog and return issues."""
+    issues = []
+
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except json.JSONDecodeError as e:
+        return [f"Invalid JSON: {e}"]
+
+    if not isinstance(data, dict):
+        return [f"Root must be a dict, got {type(data).__name__}"]
+
+    for key, value in data.items():
+        # Check for placeholders
+        if any(placeholder in key for placeholder in ["XXXXX", "□□□□", "00:00"]):
+            issues.append(f"Placeholder detected in key: {key[:50]}...")
+
+        # Check for Markdown artifacts
+        if isinstance(value, dict) and "translated" in value:
+            trans = value["translated"]
+            if "**" in trans or "*" in trans:
+                issues.append(f"Markdown artifact in: {key[:30]}... → {trans[:30]}...")
+
+        # Check normalization
+        normalized_key = unicodedata.normalize("NFKC", key)
+        if normalized_key != key:
+            issues.append(f"Key not NFKC normalized: {key[:50]}...")
+
+    return issues
+
+
+def main():
+    """Validate all translation catalogs."""
+    catalog_files = [
+        "translations_full_codex.json",
+        "translations_full_codex_cheap.json",
+        "translations_full_codex_max.json",
+        "translations_full_lm_jit.json",
+        "temp_translations_debug.json",
+    ]
+
+    all_issues = []
+    for filename in catalog_files:
+        path = Path(filename)
+        if not path.exists():
+            continue
+
+        print(f"Validating {filename}...")
+        issues = validate_catalog(path)
+        if issues:
+            print(f"  Found {len(issues)} issues:")
+            for issue in issues[:10]:
+                print(f"    - {issue}")
+            all_issues.extend(issues)
+
+    if all_issues:
+        print(f"\n❌ Total issues found: {len(all_issues)}")
+        sys.exit(1)
+
+    print("\n✅ All catalogs valid")
+
+
+if __name__ == "__main__":
+    main()

--- a/tmp_translate_lm.py
+++ b/tmp_translate_lm.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Translation batch processor for LM Studio."""
+import json
+import time
+from pathlib import Path
+import requests
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+BASE = "http://localhost:1234/v1"
+MODEL = "bartowski/Llama-3.3-70B-Instruct-GGUF"
+
+
+def translate_one(jp: str, session: requests.Session) -> str:
+    """Translate a single Japanese phrase to English."""
+    payload = {
+        "model": MODEL,
+        "messages": [
+            {"role": "system", "content": "You are a professional JP→EN translator."},
+            {"role": "user", "content": f"Translate this to natural US English:\n{jp}"},
+        ],
+        "temperature": 0.1,
+    }
+    try:
+        r = session.post(f"{BASE}/chat/completions", json=payload, timeout=60)
+        r.raise_for_status()
+        data = r.json()
+        choices = data.get("choices") or []
+        if not choices or "message" not in choices[0]:
+            raise ValueError(f"Unexpected response schema: {data!r}")
+        return choices[0]["message"]["content"].strip()
+    except (requests.RequestException, ValueError, KeyError) as e:
+        logger.warning("Translation attempt failed: %s", e)
+        raise
+
+
+def main() -> None:
+    """Main batch translation loop."""
+    with open("translation_cache_codex_cheap.json", "r", encoding="utf-8") as f:
+        src = json.load(f)
+
+    keys = list(src.keys())
+    out: dict[str, str] = {}
+    session = requests.Session()
+
+    print("Waiting 20s for model init...")
+    time.sleep(20)
+
+    for i, jp in enumerate(keys):
+        last_error = None
+        for attempt in range(6):
+            try:
+                out[jp] = translate_one(jp, session)
+                break
+            except Exception as e:  # noqa: BLE001
+                last_error = e
+                time.sleep(1 + attempt)
+        else:
+            logger.warning("Failed to translate after 6 attempts: %s... Error: %s", jp[:50], last_error)
+            out[jp] = src[jp]
+
+        if i % 50 == 0:
+            print(f"Progress: {i}/{len(keys)}")
+
+    Path("translation_cache_lm_direct.json").write_text(
+        json.dumps(out, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    full_format = {k: {"translated": v, "font_scaling": 1.0} for k, v in out.items()}
+    Path("translations_full_lm_direct.json").write_text(
+        json.dumps(full_format, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    print(f"Done: {len(out)} translations")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add API key handling guidance to the README
- normalize DOCX translation lookups with NFKC and add LM batch helper script
- introduce a translation catalog validation utility and guard async PPTX translations from unsupported models

## Testing
- python -m compileall scripts/manual_docx_translation.py scripts/validate_translation_catalogs.py tmp_translate_lm.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6927519639b4832ab0bea447df4e4fb8)